### PR TITLE
Add Embox into realtime OS list

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ seL4 | [github](https://github.com/seL4/seL4), [seL4.systems](https://sel4.syste
 RT-Thread | [github](https://github.com/RT-Thread), [rt-thread.org](https://www.rt-thread.org/) | Apache 2.0  | RT-Thread
 PikeOS | [Press release](https://www.sysgo.com/news-events/news-articles/article/sysgo-adds-risc-v-support-to-its-pikeos-real-time-operating-system) | Proprietary | SYSGO
 VxWorks | [Press release](https://www.windriver.com/news/press/pr.html?ID=22570) | Proprietary | [Wind River](https://www.windriver.com)
+Embox | [github](https://github.com/embox/embox), [embox.rocks](http://www.embox.rocks/) |  | Embox
 
 ## BSD distributions
 


### PR DESCRIPTION
In Embox project, there are supports to [RISCV](https://github.com/embox/embox/tree/master/templates/riscv) and [RISCV64](https://github.com/embox/embox/tree/master/templates/riscv64) architectures.